### PR TITLE
Decompose constructor to improve readability

### DIFF
--- a/lib/sheet.js
+++ b/lib/sheet.js
@@ -2,37 +2,38 @@
 
 const metavm = require('metavm');
 
+const getValue = (target, prop) => {
+  if (prop === 'Math') return Math;
+  const { expressions, data } = target;
+  if (!expressions.has(prop)) return data.get(prop);
+  const expression = expressions.get(prop);
+  return expression();
+};
+
+const getCell = (target, prop) => {
+  const { expressions, data } = target;
+  const collection = expressions.has(prop) ? expressions : data;
+  return collection.get(prop);
+};
+
+const setCell = (target, prop, value) => {
+  target.data.set(prop, value);
+  if (typeof value === 'string' && value[0] === '=') {
+    const src = '() => ' + value.substring(1);
+    const options = { context: target.context };
+    const script = metavm.createScript(prop, src, options);
+    target.expressions.set(prop, script.exports);
+  }
+  return true;
+};
+
 class Sheet {
   constructor() {
     this.data = new Map();
     this.expressions = new Map();
-    this.values = new Proxy(this, {
-      get(target, prop) {
-        if (prop === 'Math') return Math;
-        const { expressions, data } = target;
-        if (!expressions.has(prop)) return data.get(prop);
-        const expression = expressions.get(prop);
-        return expression();
-      },
-    });
+    this.values = new Proxy(this, { get: getValue });
     this.context = metavm.createContext(this.values);
-    this.cells = new Proxy(this, {
-      get(target, prop) {
-        const { expressions, data } = target;
-        const collection = expressions.has(prop) ? expressions : data;
-        return collection.get(prop);
-      },
-      set(target, prop, value) {
-        target.data.set(prop, value);
-        if (typeof value === 'string' && value[0] === '=') {
-          const src = '() => ' + value.substring(1);
-          const options = { context: target.context };
-          const script = metavm.createScript(prop, src, options);
-          target.expressions.set(prop, script.exports);
-        }
-        return true;
-      },
-    });
+    this.cells = new Proxy(this, { get: getCell, set: setCell });
   }
 }
 


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
